### PR TITLE
I Can't Haz template from combined ICANHAZ_DIR 

### DIFF
--- a/icanhaz/finders.py
+++ b/icanhaz/finders.py
@@ -25,7 +25,7 @@ class FilesystemFinder(BaseFinder):
                 directory,
                 name + ".html"))
 
-            if filepath.startswith(directory) and os.path.exists(filepath):
+            if filepath.startswith(os.path.normpath(directory)) and os.path.exists(filepath):
                 return filepath
 
         return None


### PR DESCRIPTION
My settings are:

DIR_NAME = os.path.dirname(**file**)
ICANHAZ_DIRS = (
    os.path.join(DIR_NAME, 'jstemplates'),
)
at this point DIR_NAME is '/home/username/workspace/proj/src/../src/jstemplates'

FilesystemFinder stuck at https://github.com/carljm/django-icanhaz/blob/master/icanhaz/finders.py#L28
because
directory is '/home/username/workspace/proj/src/../src/jstemplates'
filepath is '/home/username/workspace/proj/src/jstemplates/templatename.html'
so
filepath.startswith(directory) return False
