### PR TITLE
Allow the use of regular expressions in icanhaz template tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,18 @@ utilities; it just helps you easily embed the templates in your HTML. Include
 `ICanHaz.js`_ in your project's static assets and use it in your JS as usual.
 
 
+Regular Expressions in Template Tags
+------------------------------------
+
+Using the template tag ``{% icanhaz [directory] [regex] %}`` in your
+Django templates will embed all files matching that regex in the given
+directory.  So, ``{% icanhaz './' '.*_template' %}`` would match
+`note_template.html` and `comment_template.html`, giving them templatename
+`note_template` and `comment_template`, respectively.  (Note that the ".html"
+extension is assumed.  See the advanced usage section for how to customize
+this behavior).
+
+
 Advanced usage
 --------------
 
@@ -60,10 +72,17 @@ each app in ``INSTALLED_APPS``. The app subdirectory name(s) to check can be
 configured via the ``ICANHAZ_APP_DIRNAMES`` setting, which defaults to
 ``["jstemplates"]``.
 
-The finding of templates can be fully controlled via the ``ICANHAZ_FINDERS``
+Standard finding of templates can be fully controlled via the ``ICANHAZ_FINDERS``
 setting, which is a list of dotted paths to finder classes. A finder class
 should be instantiable with no arguments, and have a ``find(name)`` method
 which returns the full absolute path to a template file, given a base-name.
+
+Regex finding of templates can be fully controlled via the
+``ICANHAZ_REGEX_FINDERS`` setting.  A regex finder class should be
+instantiable with no arguments and have a ``find(dir, regex)`` method
+which takes in two strings (directory and regex) and returns a list of
+matches in the form `[(name, filepath)...]` where name is the id given
+to a template and filepath is a full absolute path to a template file.
 
 By default, ``ICANHAZ_FINDERS`` contains ``"icanhaz.finders.FilesystemFinder"``
 (which searches directories listed in ``ICANHAZ_DIRS``) and
@@ -71,6 +90,20 @@ By default, ``ICANHAZ_FINDERS`` contains ``"icanhaz.finders.FilesystemFinder"``
 ``ICANHAZ_APP_DIRNAMES`` of each app in ``INSTALLED_APPS``), in that order --
 thus templates found in ``ICANHAZ_DIRS`` take precedence over templates in
 apps.
+
+By default, ``ICANHAZ_REGEX_FINDERS`` contains
+``"icanhaz.finders.FilesystemRegexFinder"` (which searches directories listed
+in ``ICANHAZ_DIRS``) and ``"icanhaz.finders.AppRegexFinder"`` (which searches
+subdirectories named in ``ICANHAZ_APP_DIRNAMES`` of each app in
+``INSTALLED_APPS``).  Precedence is unimportant, as all matching templates
+are added.  Further, django-icanhaz is bundled with two convenience scoping
+regex finders: ``icanhaz.finders.ScopedFilesystemRegexFinder`` and
+``icanhaz.finders.ScopedAppRegexFinder`` which each prepend a scope derived
+from the directory path given to each name: so, if
+``{% icanhaz './all/my/templates/' '.*_template' %}`` matches
+`note_template.html` and `comment_template.html`, they will have names
+`all_my_templates_note_template` and `all_my_templates_comment_template`,
+respectively.
 
 
 Rationale

--- a/icanhaz/conf.py
+++ b/icanhaz/conf.py
@@ -22,6 +22,10 @@ conf = Configuration(
         "icanhaz.finders.FilesystemFinder",
         "icanhaz.finders.AppFinder",
         ],
+    ICANHAZ_REGEX_FINDERS=[
+        "icanhaz.finders.FilesystemRegexFinder",
+        "icanhaz.finders.AppRegexFinder",
+        ],
     ICANHAZ_DIRS=[],
     ICANHAZ_APP_DIRNAMES=["jstemplates"],
     )

--- a/icanhaz/finders.py
+++ b/icanhaz/finders.py
@@ -1,4 +1,4 @@
-import os, sys
+import os, sys, re
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.importlib import import_module
@@ -10,6 +10,15 @@ from .conf import conf
 class BaseFinder(object):
     def find(self, name):
         raise NotImplementedError()
+
+
+
+class BaseRegexFinder(object):
+    # Returns a list of (name, filepath) pairs
+    # from the given dir matching the given regex
+    def findAll(self, dir, regex):
+        raise NotImplementedError()
+
 
 
 
@@ -29,6 +38,40 @@ class FilesystemFinder(BaseFinder):
                 return filepath
 
         return None
+
+
+
+class FilesystemRegexFinder(BaseRegexFinder):
+    @property
+    def directories(self):
+        return conf.ICANHAZ_DIRS
+
+
+    def findAll(self, dir, regex):
+        result = []
+
+        regex = re.compile("(" + regex + ").html")
+        for directory in self.directories:
+            dirpath = os.path.abspath(os.path.join(directory, dir))
+            for file in os.listdir(dirpath):
+                if not os.path.isdir(file):
+                    match = regex.match(file)
+                    if match is not None:
+                        print match.groups()[0]
+                        result += [(match.groups()[0], os.path.join(dirpath, file))]
+
+        return result
+
+
+
+# Convenience subclass to add directory scope to
+# the names of the files
+class ScopedFilesystemRegexFinder(FilesystemRegexFinder):
+    def findAll(self, dir, regex):
+        res = super(ScopedFilesystemRegexFinder, self).findAll(dir, regex)
+        dir = str(os.path.join(dir))
+        scope_list = [x for x in dir.split("/") if x is not "." and len(x) > 0]
+        return [("_".join(scope_list + [name]), dir) for (name, dir) in res]
 
 
 
@@ -55,6 +98,20 @@ app_template_dirs = _get_app_template_dirs()
 
 
 class AppFinder(FilesystemFinder):
+    @property
+    def directories(self):
+        return app_template_dirs
+
+
+
+class AppRegexFinder(FilesystemRegexFinder):
+    @property
+    def directories(self):
+        return app_template_dirs
+
+
+
+class ScopedAppRegexFinder(ScopedFilesystemRegexFinder):
     @property
     def directories(self):
         return app_template_dirs

--- a/icanhaz/loading.py
+++ b/icanhaz/loading.py
@@ -15,9 +15,19 @@ def find(name):
 
 
 
-def _get_finders():
+def findAll(dir, regex):
+    result = []
+    for finder in regexfinders:
+        paths = finder.findAll(dir, regex)
+        if paths is not None:
+            result += paths
+    return result
+
+
+
+def _get_finders(finder_conf):
     ret = []
-    for finder_path in conf.ICANHAZ_FINDERS:
+    for finder_path in finder_conf:
         modpath, cls_name = finder_path.rsplit(".", 1)
         try:
             mod = import_module(modpath)
@@ -38,7 +48,8 @@ def _get_finders():
 
 
 # Instantiate finders
-finders = _get_finders()
+finders = _get_finders(conf.ICANHAZ_FINDERS)
+regexfinders = _get_finders(conf.ICANHAZ_REGEX_FINDERS)
 
 
 


### PR DESCRIPTION
Allow users to put template tags like

  {% icanhaz './comments/' '.*' %}

which match all comments/[regex match].html where [regex match] is
then used as the template name for each and all are added to the
templatized page.

Also include some convenience finders to automatically scope regex-
matched templates.  In the above example, the names would then
be comments_[regex match].
